### PR TITLE
FFL-215 - Update the Format of Customer Name and Company

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+.vscode

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -73,6 +73,9 @@ class Plugin {
 
 		// Load map experience.
 		add_action( 'woocommerce_before_checkout_shipping_form', array( Checkout::class, 'get_ffl' ) );
+		add_action('woocommerce_after_order_notes', array(Checkout::class, 'add_automaticffl_checkout_field'));
+		add_action('woocommerce_checkout_update_order_meta', array(Checkout::class, 'after_checkout_create_order'), 20, 2);
+		add_action('woocommerce_checkout_update_order_meta', array(Checkout::class, 'save_automaticffl_checkout_field_value'));
 	}
 
 	/**
@@ -91,6 +94,7 @@ class Plugin {
 
 		// Do not save shipping address.
 		add_filter( 'woocommerce_checkout_update_customer_data', array( $this, 'maybe_update_customer_data' ), 10, 2 );
+		add_filter( 'woocommerce_checkout_fields', array(Checkout::class, 'automaticffl_custom_fields') );
 	}
 
 	/**


### PR DESCRIPTION
This PR contains the following changes:

- Set the First and Last names to the current user if logged in, otherwise set it to "FFL Dealer".
- Add a field to the checkout to send the selected dealer phone number to WooCommerce Order page.
- Add a function to send the FFL License as an Order Comment so the Merchant can see it if necessary.